### PR TITLE
Patch for Julia 0.5.1.

### DIFF
--- a/src/CauseMap.jl
+++ b/src/CauseMap.jl
@@ -1,6 +1,7 @@
 module CauseMap
 using Base.LinAlg.BLAS 
 using PyCall
+using PyPlot
 
 include("plotting.jl")
 include("coord_descent_tuning.jl")
@@ -79,9 +80,9 @@ end
 
 
 function getpredstartstop(nobs::Int, ll::Int, lib_size::Int, npred::Int, pred_start_min::Int)
-    left::Int = iceil(npred / 2)
+    left::Int = ceil(Integer, npred / 2)
     right::Int = npred - left - 1
-    midpoint::Int = iceil(ll + lib_size / 2)
+    midpoint::Int = ceil(Integer, ll + lib_size / 2)
     lp::Int = midpoint - left
     rp::Int = midpoint + right
 
@@ -104,7 +105,7 @@ end
 
 
 ### this function accounts for ~70% of algorithm run time
-function calcdistslice!(source_dists::Array{Float64, 2}, dist_top::Vector{Float64}, slice_inds::AbstractVector{Int}, topred::Int, nn::Range1{Int})    
+function calcdistslice!(source_dists::Array{Float64, 2}, dist_top::Vector{Float64}, slice_inds::AbstractVector{Int}, topred::Int, nn::Range{Int})    
     if in(topred, slice_inds)
         slice_inds = convert(Vector{Int}, slice_inds)
         splice!(slice_inds, findfirst([yy == topred for yy in slice_inds])) # remove topred, but don't move any of the preceding elements in the array
@@ -261,7 +262,7 @@ function calclibstart(shadowmat_dict::Dict, E::Int, tau_s::Int)
 end
 
 function calclibsizemax(nobs::Int, E::Int, tau_s::Int, tau_p::Int)  ## REMOVE
-    return ifloor(nobs/tau_s) - E - tau_p
+    return floor(Integer, nobs/tau_s) - E - tau_p
 end
 
 function check_lib_pred_defaults(libsizemin, libsizemax, lib_start, 

--- a/src/calc_manifolds.jl
+++ b/src/calc_manifolds.jl
@@ -39,8 +39,8 @@ end
 
 
 function precalc_manif_dists(Evals::AbstractVector{Int}, tau_vals::AbstractVector{Int}, vector::AbstractVector)
-    shadowmats = (Int=>Dict)[tt => (Int=>Array{Float64,2})[E => construct_shadow(vector, E, tt) for E in Evals] for tt in tau_vals]
-    distmats   = (Int=>Dict)[tt => (Int=>Array{Float64,2})[E => calc_dists(shadowmats[tt][E]) for E in Evals] for tt in tau_vals]
+    shadowmats = Dict{Int,Dict}(tt => Dict{Int,Array{Float64,2}}(E => construct_shadow(vector, E, tt) for E in Evals) for tt in tau_vals)
+    distmats   = Dict{Int,Dict}(tt => Dict{Int,Array{Float64,2}}(E => calc_dists(shadowmats[tt][E]) for E in Evals) for tt in tau_vals)
     return shadowmats, distmats
 end
 

--- a/src/coord_descent_tuning.jl
+++ b/src/coord_descent_tuning.jl
@@ -40,7 +40,7 @@ function _CoordDescentOpt(source_series::Vector{Float64}, target_series::Vector{
 
     toopt = ["E"; "tau_s"; "tau_p"]
 
-    current_vals = {"E"=>E_vals[1], "tau_s"=> tau_s_vals[1], "tau_p"=>tau_p_vals[1]}
+    current_vals = Dict("E"=>E_vals[1], "tau_s"=> tau_s_vals[1], "tau_p"=>tau_p_vals[1])
     librange, res12 = calcCCM(source_series, target_series, 
                                                 shadowmat_dict, distmat_dict,  
                                                 current_vals["E"], current_vals["tau_s"], current_vals["tau_p"]; 
@@ -49,9 +49,9 @@ function _CoordDescentOpt(source_series::Vector{Float64}, target_series::Vector{
                                                 quick=true, nboots=nboots)
     
     rhoinit = getrho(res12)
-    best_vals = merge(current_vals, ["rho"=>rhoinit])
+    best_vals = merge(current_vals, Dict("rho"=>rhoinit))
     
-    all_vals = ["E"=>E_vals, "tau_s"=>tau_s_vals, "tau_p"=>tau_p_vals]
+    all_vals = Dict("E"=>E_vals, "tau_s"=>tau_s_vals, "tau_p"=>tau_p_vals)
 
     iternum = 1
     count = 0
@@ -80,7 +80,7 @@ end
 
 function optvar(source_series::AbstractVector, target_series::AbstractVector, shadowmat_dict::Dict, 
     distmat_dict::Dict, all_vals::Dict, current_vals::Dict, 
-    best_vals::Dict, var::ASCIIString, libsizemax::Int, npred::Int, pred_start::Int; nlag::Int=10, b_offset=1, nboots=0)
+    best_vals::Dict, var::String, libsizemax::Int, npred::Int, pred_start::Int; nlag::Int=10, b_offset=1, nboots=0)
     
     
     if length(all_vals[var]) < 2

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -120,8 +120,8 @@ function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_val
         statsuff1 = ""
         statsuff2 = ""
     end
-    stats1 = "   E = $(res12["E"]), \$\\tau_{p}\$ = $(Int(res12["tau_p"] * lagunit))" * statsuff1
-    stats2 = "   E = $(res21["E"]), \$\\tau_{p}\$ = $(Int(res21["tau_p"] * lagunit))" * statsuff2
+    stats1 = "   E = $(res12["E"]), \$\\tau_{p}\$ = $(round(Int, res12["tau_p"] * lagunit))" * statsuff1
+    stats2 = "   E = $(res21["E"]), \$\\tau_{p}\$ = $(round(Int, res21["tau_p"] * lagunit))" * statsuff2
 
     ax1 = plt.subplot2grid((2,ncols), (0,0), rowspan=2, colspan=floor(Integer, ncols/3))
     

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,6 +1,6 @@
 function makesingleplot(vec1::AbstractVector, vec2::AbstractVector, 
                                         E::Int, tau_s::Int, tau_p::Int,  
-                                        var1name::ASCIIString, var2name::ASCIIString; 
+                                        var1name::String, var2name::String; 
                                         lib_start=1, xmin=false, xmax=false, ymin=false, 
                                         ymax=false, nboots=0, plot=true, 
                                         libsizemin=0, libsizemax=0, 
@@ -61,7 +61,7 @@ end
 
 function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_vals::AbstractVector,  
                                                     tau_s_vals::AbstractVector, tau_p_vals::AbstractVector,
-                                                    var1name::ASCIIString, var2name::ASCIIString; 
+                                                    var1name::String, var2name::String; 
                                                     nreps=5, b_offset=1, ncols=28, left_E=false, left_tau_p=false, 
                                                     right_E=false, right_tau_p=false, lagunit=1, unit=false, 
                                                     imfont="medium", nboots=0, legend=true, 
@@ -87,20 +87,20 @@ function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_val
                                                 npred=npred, pred_start=pred_start, 
                                                 nreps=nreps, nboots=nboots)
     
-    libsizemin_12 = max(res12["E"] + b_offset + 1, 10)
-    libsizemin_21 = max(res21["E"] + b_offset + 1, 10)
+    libsizemin_12 = max(convert(Integer, res12["E"]) + b_offset + 1, 10)
+    libsizemin_21 = max(convert(Integer, res21["E"]) + b_offset + 1, 10)
     
     println("\nstarting calcCCM1")
     librange12, yval_12 = calcCCM(vec1, vec2, 
                                                         shadowmat_dict_vec1, distmat_dict_vec1, 
-                                                        res12["E"], res12["tau_s"], res12["tau_p"];
+                                                        convert(Integer, res12["E"]), convert(Integer, res12["tau_s"]), convert(Integer, res12["tau_p"]);
                                                         libsizemin=libsizemin_12, libsizemax=libsizemax,
                                                         npred=npred, pred_start=pred_start, 
                                                         lib_start=1, nboots=nboots)
     println("starting calcCCM2")
     librange21, yval_21 = calcCCM(vec2, vec1, 
                                                         shadowmat_dict_vec2, distmat_dict_vec2, 
-                                                        res12["E"], res12["tau_s"], res12["tau_p"];
+                                                        convert(Integer, res12["E"]), convert(Integer, res12["tau_s"]), convert(Integer, res12["tau_p"]);
                                                         libsizemin=libsizemin_21, libsizemax=libsizemax,
                                                         npred=npred, pred_start=pred_start, 
                                                         lib_start=1, nboots=nboots)
@@ -120,10 +120,10 @@ function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_val
         statsuff1 = ""
         statsuff2 = ""
     end
-    stats1 = "   E = $(res12["E"]), \$\\tau_{p}\$ = $(int(res12["tau_p"] * lagunit))" * statsuff1
-    stats2 = "   E = $(res21["E"]), \$\\tau_{p}\$ = $(int(res21["tau_p"] * lagunit))" * statsuff2
+    stats1 = "   E = $(res12["E"]), \$\\tau_{p}\$ = $(Int(res12["tau_p"] * lagunit))" * statsuff1
+    stats2 = "   E = $(res21["E"]), \$\\tau_{p}\$ = $(Int(res21["tau_p"] * lagunit))" * statsuff2
 
-    ax1 = plt.subplot2grid((2,ncols), (0,0), rowspan=2, colspan=ifloor(ncols/3))
+    ax1 = plt.subplot2grid((2,ncols), (0,0), rowspan=2, colspan=floor(Integer, ncols/3))
     
     ax1[:plot](librange12, yval_12, label="$label1\n$stats1")
     ax1[:plot](librange21, yval_21, label="$label2\n$stats2")
@@ -140,7 +140,7 @@ function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_val
     
     mat12, Es12, taus12 = get_E_taupcurves(vec1, vec2, 
                                                                         shadowmat_dict_vec1, distmat_dict_vec1, 
-                                                                        libsizemax, res12["E"], res12["tau_s"], res12["tau_p"], 
+                                                                        libsizemax, convert(Integer, res12["E"]), convert(Integer, res12["tau_s"]), convert(Integer, res12["tau_p"]), 
                                                                         E_vals, tau_p_vals, npred, pred_start; 
                                                                         left_E=left_E, left_tau_p=left_tau_p, 
                                                                         right_E=right_E, right_tau_p=right_tau_p, nboots=nboots
@@ -148,7 +148,7 @@ function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_val
     
     mat21, Es21, taus21 = get_E_taupcurves(vec2, vec1, 
                                                                         shadowmat_dict_vec2, distmat_dict_vec2,
-                                                                        libsizemax, res21["E"], res21["tau_s"], res21["tau_p"], 
+                                                                        libsizemax, convert(Integer, res21["E"]), convert(Integer, res21["tau_s"]), convert(Integer, res21["tau_p"]), 
                                                                         E_vals, tau_p_vals, npred, pred_start;
                                                                         left_E=left_E, left_tau_p=left_tau_p, 
                                                                         right_E=right_E, right_tau_p=right_tau_p, nboots=nboots
@@ -171,10 +171,10 @@ function makeoptimizationplots(vec1::AbstractVector, vec2::AbstractVector, E_val
         xlabel =  "\$\\tau_p\$"
     end
 
-    ax2 = plt.subplot2grid((2,ncols), (0,ifloor(ncols/3)), colspan=2*ifloor(ncols/3))
+    ax2 = plt.subplot2grid((2,ncols), (0,floor(Integer, ncols/3)), colspan=2*floor(Integer, ncols/3))
     imax12 = plotheatmap(ax2, mat12, vmin, vmax, label1, taus12, Es12, imfont, lagunit, xlabel)
 
-    ax3 = plt.subplot2grid((2,ncols), (1,ifloor(ncols/3)), colspan=2*ifloor(ncols/3))
+    ax3 = plt.subplot2grid((2,ncols), (1,floor(Integer, ncols/3)), colspan=2*floor(Integer, ncols/3))
     imax21 = plotheatmap(ax3, mat21, vmin, vmax, label2, taus21, Es21, imfont, lagunit, xlabel)
 
     ax4 = plt.subplot2grid((2,ncols), (0,ncols-1), rowspan=2)  # axis for colorbar
@@ -198,8 +198,8 @@ function get_totest(val::Int, numtotest::Int, minval::Int, maxval::Int)
         maxval = minval + numtotest - 1  
     end
     
-    left::Int  = val-iceil(numtotest/2) 
-    right::Int = val+ifloor(numtotest/2)-1
+    left::Int  = val-ceil(Integer, numtotest/2) 
+    right::Int = val+floor(Integer, numtotest/2)-1
     
     if left < minval
         right += (minval-left)


### PR DESCRIPTION
This commit allows the quickstart code to run on the latest version of
Julia (0.5.1). Quite a few methods and some syntax has been deprecated
in the last two years. This patch replaces these with the equivalent
new methods and syntax.

Included changes:
- Rewrite deprecated Dict declarations.
- Use String instead of deprecated ASCIIString.
- Use Int instead of deprecated int.
- Use ceil(Integer, x) instead of deprecated iceil(x).
- Use floor(Integer, x) instead of deprecated ifloor(x).
- Import PyPlot to automatically resolve matplotlib dependency.
- Explicitly convert E, tua_s and tua_p to Integer when needed. (nasty!)
- Use Range instead of Range1. (typo?)

Tested using http://cyrusmaher.github.io/CauseMap.jl/Quickstart.html. I
did not test with any other data or settings.

The graph output looks aesthetically different, but seems okay in terms
of the data. I suspect this is the result of changes to matplotlib, but
I did not investigate further.

I believe this commit also fixes #12 and fixes #13.